### PR TITLE
Input rules support aria label

### DIFF
--- a/lib/rules/input-components-require-accessible-name.ts
+++ b/lib/rules/input-components-require-accessible-name.ts
@@ -3,7 +3,7 @@
 
 import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 import { elementType } from "jsx-ast-utils";
-import { isInsideLabelTag, hasAssociatedLabelViaHtmlFor, hasAssociatedLabelViaAriaLabelledBy } from "../util/labelUtils";
+import { isInsideLabelTag, hasAssociatedLabelViaHtmlFor, hasAssociatedLabelViaAriaLabelledBy, hasAriaLabel } from "../util/labelUtils";
 import { hasFieldParent } from "../util/hasFieldParent";
 import { applicableComponents } from "../applicableComponents/inputBasedComponents";
 import { JSXOpeningElement } from "estree-jsx";
@@ -41,8 +41,9 @@ const rule = ESLintUtils.RuleCreator.withoutDocs({
                     return;
                 }
 
-                // wrapped in Label tag, labelled with htmlFor, labelled with aria-labelledby
+                // wrapped in Label tag, labelled with htmlFor, labelled with aria-labelledby, labelled with aria-label
                 if (
+                    hasAriaLabel(node) ||
                     hasFieldParent(context) ||
                     isInsideLabelTag(context) ||
                     hasAssociatedLabelViaHtmlFor(node, context) ||

--- a/lib/util/labelUtils.js
+++ b/lib/util/labelUtils.js
@@ -142,6 +142,17 @@ function hasAssociatedAriaText(openingElement, context, ariaAttribute) {
     return hasAssociatedAriaText && hasHtmlId;
 }
 
+/**
+ * Determines if the element has a non-empty aria-label attribute.
+ * e.g.
+ * <Input aria-label="Sample label" />
+ * @param {*} openingElement
+ * @returns boolean for match found or not.
+ */
+function hasAriaLabel(openingElement) {
+    return hasNonEmptyProp(openingElement.attributes, "aria-label");
+}
+
 module.exports = {
     isInsideLabelTag,
     hasLabelWithHtmlForId,
@@ -149,5 +160,6 @@ module.exports = {
     hasAssociatedLabelViaAriaLabelledBy,
     hasAssociatedLabelViaHtmlFor,
     hasAssociatedLabelViaAriaDescribedby,
-    hasAssociatedAriaText
+    hasAssociatedAriaText,
+    hasAriaLabel
 };


### PR DESCRIPTION
In the rules of the input component, you may have forgotten to add the detection rules of arialabel.

Fixes #128 