### PR TITLE
Fixes #136

### DIFF
--- a/lib/rules/accordion-item-needs-header-and-panel.ts
+++ b/lib/rules/accordion-item-needs-header-and-panel.ts
@@ -25,9 +25,11 @@ const rule = ESLintUtils.RuleCreator.withoutDocs({
     create(context) {
         return {
             JSXOpeningElement(node: TSESTree.JSXOpeningElement) {
-                if (node.name.type === AST_NODE_TYPES.JSXIdentifier && node.name.name !== "AccordionItem") {
-                    return;
-                }
+                const isAccordionItem =
+                    node.name.type === AST_NODE_TYPES.JSXIdentifier &&
+                    node.name.name === "AccordionItem";
+
+                if (!isAccordionItem) return;
 
                 if (!(node.parent && node.parent.type === AST_NODE_TYPES.JSXElement)) {
                     return;

--- a/lib/rules/dialogbody-needs-title-content-and-actions.ts
+++ b/lib/rules/dialogbody-needs-title-content-and-actions.ts
@@ -25,7 +25,11 @@ const rule = ESLintUtils.RuleCreator.withoutDocs({
     create(context) {
         return {
             JSXOpeningElement(node: TSESTree.JSXOpeningElement) {
-                if (node.name.type === AST_NODE_TYPES.JSXIdentifier && node.name.name !== "DialogBody") {
+                const isDialogBody =
+                    node.name.type === AST_NODE_TYPES.JSXIdentifier &&
+                    node.name.name === "DialogBody";
+
+                if (!isDialogBody) {
                     return;
                 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/eslint-plugin-fluentui-jsx-a11y",
-    "version": "3.0.0-alpha.1",
+    "version": "3.0.0-alpha.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/eslint-plugin-fluentui-jsx-a11y",
-            "version": "3.0.0-alpha.1",
+            "version": "3.0.0-alpha.2",
             "license": "MIT",
             "dependencies": {
                 "eslint-plugin-header": "^3.1.1",

--- a/tests/lib/rules/accordion-item-needs-header-and-panel.test.ts
+++ b/tests/lib/rules/accordion-item-needs-header-and-panel.test.ts
@@ -15,7 +15,8 @@ import rule from "../../../lib/rules/accordion-item-needs-header-and-panel";
 
 ruleTester.run("accordion-item-needs-header-and-panel", rule as unknown as Rule.RuleModule, {
     valid: [
-        `<AccordionItem><AccordionHeader>Accordion Header 1</AccordionHeader><AccordionPanel><div>Accordion Panel 1</div></AccordionPanel></AccordionItem>`
+        `<AccordionItem><AccordionHeader>Accordion Header 1</AccordionHeader><AccordionPanel><div>Accordion Panel 1</div></AccordionPanel></AccordionItem>`,
+        `<React.StrictMode><Component /></React.StrictMode>`
     ],
 
     invalid: [

--- a/tests/lib/rules/dialogbody-needs-title-content-and-actions.test.ts
+++ b/tests/lib/rules/dialogbody-needs-title-content-and-actions.test.ts
@@ -22,7 +22,8 @@ ruleTester.run("dialogbody-needs-title-content-and-actions", rule as any as Rule
                 <Button>Close</Button>
                 <Button>Do Something</Button>
             </DialogActions>
-        </DialogBody>`
+        </DialogBody>`,
+        `<React.StrictMode><Component /></React.StrictMode>`
     ],
 
     invalid: [


### PR DESCRIPTION
The issue was caused by faulty logic in the rule body with conditionals. 

e.g. 

What happened before
```
if (node.name.type === JSXIdentifier && node.name.name !== "DialogBody") {
  return;
}

<DialogBody> → true && false → do not return → rule runs ✅
<Foo> → true && true → return ✅
<React.StrictMode> → false && … → do not return → rule runs ❌ (bug)

The first operand is false for JSXMemberExpression, so the whole if is false and you don’t return, meaning the rule keeps running on <React.StrictMode>.
```

What the new guard does
```
const isDialogBody =
  node.name.type === AST_NODE_TYPES.JSXIdentifier &&
  node.name.name === "DialogBody";

if (!isDialogBody) return;


<DialogBody> → true && true → isDialogBody = true → do not return → rule runs ✅

<Foo> → true && false → isDialogBody = false → return ✅

<React.StrictMode> → false && … → isDialogBody = false → return ✅

Now you only proceed when it’s exactly a JSXIdentifier("DialogBody"); everything else (including JSXMemberExpression) exits early. That’s why it fixes the squiggle on <React.StrictMode>.
```