### PR TITLE
Set up eslint configuration for TypeScript files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,26 @@ module.exports = {
         {
             files: ["tests/**/*.js"],
             env: { mocha: true }
+        },
+        {
+            files: ["tests/**/*.ts"],
+            env: { jest: true }
+        },
+        {
+            files: ["**/*.ts"],
+            parser: "@typescript-eslint/parser",
+            plugins: ["@typescript-eslint"],
+            parserOptions: {
+                ecmaVersion: 2021,
+                sourceType: "module",
+                project: "./tsconfig.json"
+            },
+            rules: {
+                // Disable Node.js rules that conflict with TypeScript
+                "node/no-missing-import": "off",
+                "node/no-unsupported-features/es-syntax": "off",
+                "node/no-extraneous-import": "off"
+            }
         }
     ],
     rules: {

--- a/lib/applicableComponents/labelBasedComponents.ts
+++ b/lib/applicableComponents/labelBasedComponents.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 const labelBasedComponents = ["Label", "label"];
 const elementsUsedAsLabels = ["div", "span", "p", "h1", "h2", "h3", "h4", "h5", "h6"];
 

--- a/lib/rules/field-needs-labelling.ts
+++ b/lib/rules/field-needs-labelling.ts
@@ -3,7 +3,7 @@
 
 "use strict";
 
-const { hasNonEmptyProp } = require("../util/hasNonEmptyProp");
+import { hasNonEmptyProp } from "../util/hasNonEmptyProp";
 const elementType = require("jsx-ast-utils").elementType;
 import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 

--- a/lib/rules/index.ts
+++ b/lib/rules/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 export { default as accordionHeaderNeedsLabelling } from "./accordion-header-needs-labelling";
 export { default as accordionItemNeedsHeaderAndPanel } from "./accordion-item-needs-header-and-panel";
 export { default as avatarNeedsName } from "./avatar-needs-name";

--- a/tests/lib/rules/utils/hasFieldParent.test.ts
+++ b/tests/lib/rules/utils/hasFieldParent.test.ts
@@ -25,9 +25,11 @@ const createMockContext = (ancestors: TSESTree.Node[]): TSESLint.RuleContext<str
     report: jest.fn(),
     getAncestors: () => ancestors,
     getSourceCode: jest.fn(),
+    // eslint-disable-next-line no-unused-vars
     getDeclaredVariables: function (node: TSESTree.Node): readonly TSESLint.Scope.Variable[] {
         throw new Error("Function not implemented.");
     },
+    // eslint-disable-next-line no-unused-vars
     markVariableAsUsed: function (name: string): boolean {
         throw new Error("Function not implemented.");
     }

--- a/tests/lib/rules/utils/hasLabelledChilImage.test.ts
+++ b/tests/lib/rules/utils/hasLabelledChilImage.test.ts
@@ -1,4 +1,6 @@
-// Import necessary dependencies and mock functions
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import {
     hasLabelledChildImage,
     isImageHidden,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
         "rootDir": ".",
         "allowJs": true
     },
-    "include": ["lib"],
+    "include": ["lib", "tests/lib"],
     "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
I noticed that TypeScript files were not displaying eslint errors/warnings. Not sure if there's past context I'm missing, but I added the setup in this PR. This is also a requirement in order to eventually implement the [`sort-imports`](https://eslint.org/docs/latest/rules/sort-imports) rule as mentioned in #123.

Before:
<img width="855" height="181" alt="image" src="https://github.com/user-attachments/assets/3aefa174-bd15-480d-9d8c-41dc195f1fb4" />
<img width="783" height="150" alt="image" src="https://github.com/user-attachments/assets/61a3eb17-c343-42a8-9371-0a89825cec0d" />

After:
<img width="774" height="185" alt="image" src="https://github.com/user-attachments/assets/3cab95f8-3753-4988-8859-ca52536a41d1" />
<img width="1526" height="637" alt="image" src="https://github.com/user-attachments/assets/8ba8ef3b-8cf7-47a8-8de0-8b3832b427d0" />
